### PR TITLE
walkaround for incomplete connection issue

### DIFF
--- a/lab02/flight.py
+++ b/lab02/flight.py
@@ -90,21 +90,6 @@ class SimpleClient:
                 for v in logconf.variables:
                     print(f' - {v.name}')
 
-        # Reset the stock EKF
-        self.cf.param.set_value('kalman.resetEstimation', 1)
-
-        # Enable the controller (1 for stock controller, 4 for ae483 controller)
-        if self.use_controller:
-            self.cf.param.set_value('stabilizer.controller', 4)
-        else:
-            self.cf.param.set_value('stabilizer.controller', 1)
-
-        # Enable the observer (0 for disable, 1 for enable)
-        if self.use_observer:
-            self.cf.param.set_value('ae483par.use_observer', 1)
-        else:
-            self.cf.param.set_value('ae483par.use_observer', 0)
-
     def connection_failed(self, uri, msg):
         print(f'Connection to {uri} failed: {msg}')
 
@@ -144,16 +129,35 @@ class SimpleClient:
         with open(filename, 'w') as outfile:
             json.dump(self.data, outfile, indent=4, sort_keys=False)
 
+    def set_params(self):
+        # Reset the stock EKF
+        self.cf.param.set_value('kalman.resetEstimation', 1)
+
+        # Enable the controller (1 for stock controller, 4 for ae483 controller)
+        if self.use_controller:
+            self.cf.param.set_value('stabilizer.controller', 4)
+        else:
+            self.cf.param.set_value('stabilizer.controller', 1)
+
+        # Enable the observer (0 for disable, 1 for enable)
+        if self.use_observer:
+            self.cf.param.set_value('ae483par.use_observer', 1)
+        else:
+            self.cf.param.set_value('ae483par.use_observer', 0)
+
 if __name__ == '__main__':
     # Initialize everything
     logging.basicConfig(level=logging.ERROR)
     cflib.crtp.init_drivers()
 
     # Create and start the client that will connect to the drone
-    client = SimpleClient(uri, use_controller=False, use_observer=False)
+    client = SimpleClient(uri, use_controller=True, use_observer=False)
     while not client.is_connected:
         print(f' ... connecting ...')
         time.sleep(1.0)
+
+    # Set parameters after the client is connected
+    client.set_params()
 
     # Leave a little time at the start to initialize
     client.stop(1.0)


### PR DESCRIPTION
This is a walkaround for resolving the issue similar to what #1 brings up. In my case, the problem with the current version of the base repo is twofold:
- Data cannot be logged in a json file
- Setting up an argument `use_controller=True` when generating an instance of `SimpleClient` makes my Crazyflie fly, which is not intentional with our [firmware](https://github.com/tbretl/crazyflie-firmware)

I tried running #1, but I found that my `cflib` python library lacks the `fully_connected` variable for `Crazyflie` class (as appears in [here](https://github.com/bitcraze/crazyflie-lib-python/blob/03053503be927d8e259c1d0eeb5127a9fbb8c318/cflib/crazyflie/__init__.py)) so it didn't work. I don't know why it fails even though I've installed its latest version (=0.1.19) using `pip` command.

Instead of using `fully_connected`, I suggest a walkaround here; it seamlessly works for our class material (at least for lab2) with resolving the aforementioned issues.

@ To the author of #1, would you mind if you could check this modification out whether or not it resolves the "spiking issue" at the very beginning of the logged data?