### PR TITLE
Change the timekeeping method for logging CF variables.

### DIFF
--- a/lab02/flight.py
+++ b/lab02/flight.py
@@ -117,8 +117,9 @@ class SimpleClient:
         self.is_fully_connected = False
 
     def log_data(self, timestamp, data, logconf):
+        t_ms = time.time() * 1000
         for v in logconf.variables:
-            self.data[v.name]['time'].append(timestamp)
+            self.data[v.name]['time'].append(t_ms)
             self.data[v.name]['data'].append(data[v.name])
 
     def log_error(self, logconf, msg):


### PR DESCRIPTION
Why? 

In order to log mocap data in addition to the CF variables, and to also plot both of these sets of data on the same time axis, we need a common 'timekeeper'. Currently, 'flight.py' uses the timstamps (based on the STM32 clock) sent back along with the CF data. 

Solution:

Replace the CF timestamps with a call to 'time.time()'.